### PR TITLE
feat(sast): add option of count in file names in tests 

### DIFF
--- a/tests/common/graph/checks/test_yaml_policies_base.py
+++ b/tests/common/graph/checks/test_yaml_policies_base.py
@@ -128,6 +128,13 @@ def get_expected_results_by_file_name(test_dir: str | Path) -> (list[str], list[
 
 
 def extract_real_count_of_tests_by_filename(files: list[str]):
+    """
+    >>> extract_real_count_of_tests_by_filename(['fail.json', 'fail1.json'])
+    2
+
+    >>> extract_real_count_of_tests_by_filename(['fail__11__.json', 'fail1.json'])
+    12
+    """
     total_count = 0
     for fn in files:
         name_parts = fn.split('__')

--- a/tests/common/graph/checks/test_yaml_policies_base.py
+++ b/tests/common/graph/checks/test_yaml_policies_base.py
@@ -127,6 +127,17 @@ def get_expected_results_by_file_name(test_dir: str | Path) -> (list[str], list[
     return (expected_fail, expected_pass)
 
 
+def extract_real_count_of_tests_by_filename(files: list[str]):
+    total_count = 0
+    for fn in files:
+        name_parts = fn.split('__')
+        if len(name_parts) == 3 and name_parts[1].isdigit():
+            total_count += int(name_parts[1])
+        else:
+            total_count += 1
+    return total_count
+
+
 def get_policy_results(root_folder, policy):
     check_id = policy['metadata']['id']
     graph_runner = Runner()

--- a/tests/sast/test_checks.py
+++ b/tests/sast/test_checks.py
@@ -9,7 +9,8 @@ import pytest
 from checkov.sast.runner import Runner
 from checkov.sast.checks_infra.registry import registry
 from checkov.runner_filter import RunnerFilter
-from tests.common.graph.checks.test_yaml_policies_base import load_yaml_data, get_expected_results_by_file_name
+from tests.common.graph.checks.test_yaml_policies_base import load_yaml_data, get_expected_results_by_file_name, \
+    extract_real_count_of_tests_by_filename
 
 BASE_DIR = Path(__file__).parent / 'checks'
 CHECK_ID_MAP: "dict[str, str]" = {}  # will be filled via setup()
@@ -138,12 +139,13 @@ def run_check(lang: str, check: str) -> None:
     failed_checks = {check.file_path.lstrip("/") for check in report.failed_checks}
 
     # get expected results
-    expected_to_fail, _ = get_expected_results_by_file_name(test_dir=test_files_dir)
+    expected_to_fail_files, _ = get_expected_results_by_file_name(test_dir=test_files_dir)
+    expected_to_fail_count = extract_real_count_of_tests_by_filename(expected_to_fail_files)
 
     # check, if results are correct
-    assert summary["failed"] == len(expected_to_fail)
+    assert summary["failed"] == expected_to_fail_count
     assert summary["passed"] == 0
     assert summary["skipped"] == 0
     assert summary["parsing_errors"] == 0
 
-    assert failed_checks == set(expected_to_fail)
+    assert failed_checks == set(expected_to_fail_files)


### PR DESCRIPTION
allow adding `__#num__` to the name of the check to state the number of failing cases.
its good specifically for sast checks, which may have 10s of functions with the same behaviour, and it doesn't make sense to create 10s of new files.
