### PR TITLE
feat(sast): add manual test to get policy parsing results

### DIFF
--- a/tests/sast/test_parser.py
+++ b/tests/sast/test_parser.py
@@ -471,9 +471,9 @@ def test_manually_bql_to_semgrep_parsing():
     2. Uncomment the rest of the test and make it run
     3. Check the parsed rules file './parsed_semgrep_rules.yaml' to review the parsed results
     """
-    bql_policies_dir = '/Users/arielk/Desktop/bridgecrew/platform/devTools/semgrep-to-bql/output'  # absolute path to a directory that contains bql policy yaml files
+    bql_policies_dir = ''  # absolute path to a directory that contains bql policy yaml files
 
-    registry = Registry(checks_dir=bql_policies_dir)
-    registry.load_rules(['all'], None)
-    registry.temp_semgrep_rules_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'parsed_semgrep_rules.yaml')
-    registry.create_temp_rules_file()
+    # registry = Registry(checks_dir=bql_policies_dir)
+    # registry.load_rules(['all'], None)
+    # registry.temp_semgrep_rules_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'parsed_semgrep_rules.yaml')
+    # registry.create_temp_rules_file()

--- a/tests/sast/test_parser.py
+++ b/tests/sast/test_parser.py
@@ -471,9 +471,9 @@ def test_manually_bql_to_semgrep_parsing():
     2. Uncomment the rest of the test and make it run
     3. Check the parsed rules file './parsed_semgrep_rules.yaml' to review the parsed results
     """
-    bql_policies_dir = ''  # absolute path to a directory that contains bql policy yaml files
+    bql_policies_dir = '/Users/arielk/Desktop/bridgecrew/platform/devTools/semgrep-to-bql/output'  # absolute path to a directory that contains bql policy yaml files
 
-    # registry = Registry(checks_dir=bql_policies_dir)
-    # registry.load_rules([], {SastLanguages.PYTHON})
-    # registry.temp_semgrep_rules_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'parsed_semgrep_rules.yaml')
-    # registry.create_temp_rules_file()
+    registry = Registry(checks_dir=bql_policies_dir)
+    registry.load_rules(['all'], None)
+    registry.temp_semgrep_rules_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'parsed_semgrep_rules.yaml')
+    registry.create_temp_rules_file()

--- a/tests/sast/test_parser.py
+++ b/tests/sast/test_parser.py
@@ -1,4 +1,8 @@
+import os
+
+from checkov.sast.checks_infra.base_registry import Registry
 from checkov.sast.checks_infra.checks_parser import SastCheckParser
+from checkov.sast.consts import SastLanguages
 
 
 def test_metadata_parsing():
@@ -457,3 +461,19 @@ def test_complex_policy_parsing():
             }
         ]
     }
+
+def test_manually_bql_to_semgrep_parsing():
+    """
+    This test is not really a full test by itself, just a util for manual testing
+    It can be used for manually reviewing the parsed results of our bql to semgrep parser
+    Usage instructions:
+    1. Fill the bql_policies_dir with a path to a directory with bql yaml policies
+    2. Uncomment the rest of the test and make it run
+    3. Check the parsed rules file './parsed_semgrep_rules.yaml' to review the parsed results
+    """
+    bql_policies_dir = ''  # absolute path to a directory that contains bql policy yaml files
+
+    # registry = Registry(checks_dir=bql_policies_dir)
+    # registry.load_rules([], {SastLanguages.PYTHON})
+    # registry.temp_semgrep_rules_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'parsed_semgrep_rules.yaml')
+    # registry.create_temp_rules_file()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

This test is not really a full test by itself, just a util for manual testing
 It can be used for manually reviewing the parsed results of our bql to semgrep parser

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
