### PR TITLE
feat(general): Add Python CKV_AWS_26

### DIFF
--- a/checkov/cdk/checks/python/SNSTopicEncryption.yaml
+++ b/checkov/cdk/checks/python/SNSTopicEncryption.yaml
@@ -1,0 +1,13 @@
+metadata:
+  version: 0.2
+  approach: define failing
+  id: CKV_AWS_26
+  name: Ensure all data stored in the SNS topic is encrypted
+  category: Encryption
+scope:
+  languages:
+    - python
+definition:
+  pattern: aws_cdk.aws_sns.Topic(<ANY>)
+  conditions:
+    - not_pattern: aws_cdk.aws_sns.Topic(<ANY>,master_key=$ARG)

--- a/tests/cdk/checks/python/SNSTopicEncryption/fail.py
+++ b/tests/cdk/checks/python/SNSTopicEncryption/fail.py
@@ -1,0 +1,23 @@
+from constructs import Construct
+from aws_cdk import (
+    App, 
+    Stack,
+    aws_sns as sns,
+    aws_kms as kms
+)
+
+
+class MyStack(Stack):
+
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # Create an SNS Topic with the KMS key
+        topic = sns.Topic(self, "Topic",
+                          topic_name="my-topic",
+                          )
+
+app = App()
+MyStack(app, "MyStack")
+app.synth()
+

--- a/tests/cdk/checks/python/SNSTopicEncryption/pass.py
+++ b/tests/cdk/checks/python/SNSTopicEncryption/pass.py
@@ -1,0 +1,26 @@
+from constructs import Construct
+from aws_cdk import (
+    App, 
+    Stack,
+    aws_sns as sns,
+    aws_kms as kms
+)
+
+
+class MyStack(Stack):
+
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # Create a KMS key
+        key = kms.Key(self, "MyKey")
+
+        # Create an SNS Topic with the KMS key
+        topic = sns.Topic(self, "Topic",
+                          topic_name="my-topic",
+                          master_key=key)
+
+app = App()
+MyStack(app, "MyStack")
+app.synth()
+

--- a/tests/cdk/checks/test_checks_python.py
+++ b/tests/cdk/checks/test_checks_python.py
@@ -23,3 +23,7 @@ def test_CKV_AWS_145_S3BucketKMSEncryption():
 
 def test_CKV2_AWS_6_S3BucketPublicAccessBlock():
     run(check_name="S3BucketPublicAccessBlock")
+
+
+def test_CKV_AWS_26_SNSTopicEncryption():
+    run(check_name="SNSTopicEncryption")


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Add Python CKV_AWS_26 policy

