### PR TITLE
feat(general): Add CKV_AWS_20

### DIFF
--- a/checkov/cdk/checks/python/S3PublicACLRead.yaml
+++ b/checkov/cdk/checks/python/S3PublicACLRead.yaml
@@ -1,0 +1,20 @@
+metadata:
+  version: 0.2
+  approach: define failing
+  id: CKV_AWS_20
+  name: Ensure the S3 bucket does not allow READ permissions to everyone
+  category: GENERAL_SECURITY
+scope:
+  languages:
+    - python
+definition:
+  or:
+  - pattern: aws_cdk.aws_s3.Bucket(<ANY>, 
+                access_control=s3.BucketAccessControl.PUBLIC_READ,
+                <ANY>)
+  - pattern: aws_cdk.aws_s3.Bucket(<ANY>, 
+                access_control=s3.BucketAccessControl.PUBLIC_READ_WRITE,
+                <ANY>)
+  - pattern: aws_cdk.aws_s3.Bucket(<ANY>, 
+                public_read_access=True,
+                <ANY>)

--- a/tests/cdk/checks/python/S3PublicACLRead/fail.py
+++ b/tests/cdk/checks/python/S3PublicACLRead/fail.py
@@ -1,0 +1,20 @@
+from constructs import Construct
+from aws_cdk import App, Stack 
+from aws_cdk import (
+    aws_s3 as s3
+)
+
+
+class MyS3Stack(Stack):
+
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        bucket = s3.Bucket(self, "MyPublicReadBucket",
+                            bucket_name="my-public-read-bucket",  # replace with your desired bucket name
+                            access_control=s3.BucketAccessControl.PUBLIC_READ
+                            )
+        
+app = App()
+MyS3Stack(app, "MyS3Stack")
+app.synth()

--- a/tests/cdk/checks/python/S3PublicACLRead/fail2.py
+++ b/tests/cdk/checks/python/S3PublicACLRead/fail2.py
@@ -1,0 +1,20 @@
+from constructs import Construct
+from aws_cdk import App, Stack 
+from aws_cdk import (
+    aws_s3 as s3
+)
+
+
+class MyS3Stack(Stack):
+
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        bucket = s3.Bucket(self, "MyPublicReadBucket",
+                            bucket_name="my-public-read-bucket",  # replace with your desired bucket name
+                            access_control=s3.BucketAccessControl.PUBLIC_READ_WRITE
+                            )
+        
+app = App()
+MyS3Stack(app, "MyS3Stack")
+app.synth()

--- a/tests/cdk/checks/python/S3PublicACLRead/fail3.py
+++ b/tests/cdk/checks/python/S3PublicACLRead/fail3.py
@@ -1,0 +1,20 @@
+from constructs import Construct
+from aws_cdk import App, Stack 
+from aws_cdk import (
+    aws_s3 as s3
+)
+
+
+class MyS3Stack(Stack):
+
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        bucket = s3.Bucket(self, "MyPublicReadBucket",
+                            bucket_name="my-public-read-bucket",  # replace with your desired bucket name
+                            public_read_access=True
+                            )
+        
+app = App()
+MyS3Stack(app, "MyS3Stack")
+app.synth()

--- a/tests/cdk/checks/python/S3PublicACLRead/pass.py
+++ b/tests/cdk/checks/python/S3PublicACLRead/pass.py
@@ -1,0 +1,19 @@
+from constructs import Construct
+from aws_cdk import App, Stack 
+from aws_cdk import (
+    aws_s3 as s3
+)
+
+
+class MyS3Stack(Stack):
+
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        bucket = s3.Bucket(self, "MyPublicReadBucket",
+                            bucket_name="my-public-read-bucket"  # replace with your desired bucket name
+                            )
+        
+app = App()
+MyS3Stack(app, "MyS3Stack")
+app.synth()

--- a/tests/cdk/checks/python/S3PublicACLRead/pass2.py
+++ b/tests/cdk/checks/python/S3PublicACLRead/pass2.py
@@ -1,0 +1,20 @@
+from constructs import Construct
+from aws_cdk import App, Stack 
+from aws_cdk import (
+    aws_s3 as s3
+)
+
+
+class MyS3Stack(Stack):
+
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        bucket = s3.Bucket(self, "MyPublicReadBucket",
+                            bucket_name="my-public-read-bucket",  # replace with your desired bucket name
+                            access_control=s3.BucketAccessControl.PRIVATE
+                            )
+        
+app = App()
+MyS3Stack(app, "MyS3Stack")
+app.synth()

--- a/tests/cdk/checks/test_checks_python.py
+++ b/tests/cdk/checks/test_checks_python.py
@@ -23,3 +23,7 @@ def test_CKV_AWS_145_S3BucketKMSEncryption():
 
 def test_CKV2_AWS_6_S3BucketPublicAccessBlock():
     run(check_name="S3BucketPublicAccessBlock")
+
+
+def test_CKV_AWS_20_S3PublicACLRead():
+    run(check_name="S3PublicACLRead")


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Add Python CDK version of CKV_AWS_20. One thing to note - all match the CloudFormation check post-synth except "public_read_access=True" which generates an bucket policy for READ access not using Access Control. We may want to update CKV_AWS_20 for this use case.
