### PR TITLE
feat(general): Convert Python AWS CDK policies to V2

### DIFF
--- a/checkov/cdk/checks/python/S3BucketEncryption.yaml
+++ b/checkov/cdk/checks/python/S3BucketEncryption.yaml
@@ -9,7 +9,7 @@ scope:
     - python
 definition:
   - or:
-    - pattern: "aws_cdk.aws_s3.Bucket(...)"
+    - pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"
       conditions:
-        - not_pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, ...)"
-    - pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.UNENCRYPTED, ...)"
+        - not_pattern: "aws_cdk.aws_s3.Bucket(<ANY>, encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, <ANY>)"
+    - pattern: "aws_cdk.aws_s3.Bucket(<ANY>, encryption=aws_cdk.aws_s3.BucketEncryption.UNENCRYPTED, <ANY>)"

--- a/checkov/cdk/checks/python/S3BucketEncryption.yaml
+++ b/checkov/cdk/checks/python/S3BucketEncryption.yaml
@@ -8,8 +8,11 @@ scope:
   languages:
     - python
 definition:
-  - or:
-    - pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"
+  or:
+    - pattern: aws_cdk.aws_s3.Bucket(<ANY>)
       conditions:
-        - not_pattern: "aws_cdk.aws_s3.Bucket(<ANY>, encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, <ANY>)"
-    - pattern: "aws_cdk.aws_s3.Bucket(<ANY>, encryption=aws_cdk.aws_s3.BucketEncryption.UNENCRYPTED, <ANY>)"
+        - not_pattern: aws_cdk.aws_s3.Bucket(<ANY>, encryption=$ENC, <ANY>)
+    - pattern: aws_cdk.aws_s3.Bucket(<ANY>, encryption=$ENC, <ANY>)
+      conditions:
+        - metavariable: $ENC
+          pattern: aws_cdk.aws_s3.BucketEncryption.UNENCRYPTED

--- a/checkov/cdk/checks/python/S3BucketEncryption.yaml
+++ b/checkov/cdk/checks/python/S3BucketEncryption.yaml
@@ -1,20 +1,15 @@
 metadata:
-  version: 0.1
+  version: 0.2
   id: CKV_AWS_19
   name: Ensure all data stored in the S3 bucket is securely encrypted at rest
   category: ENCRYPTION
+  approach: define failing
 scope:
   languages:
     - python
 definition:
   - or:
-      - and:
-          - cond_type: pattern
-            operator: equals
-            value: "aws_cdk.aws_s3.Bucket(...)"
-          - cond_type: pattern
-            operator: not_equals
-            value: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, ...)"
-      - cond_type: pattern
-        operator: equals
-        value: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.UNENCRYPTED, ...)"
+    - pattern: "aws_cdk.aws_s3.Bucket(...)"
+      conditions:
+        - not_pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, ...)"
+    - pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.UNENCRYPTED, ...)"

--- a/checkov/cdk/checks/python/S3BucketKMSEncryption.yaml
+++ b/checkov/cdk/checks/python/S3BucketKMSEncryption.yaml
@@ -9,10 +9,10 @@ scope:
     - python
 definition:
   - or:
-    - pattern: "aws_cdk.aws_s3.Bucket(...)"
+    - pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"
       conditions:
-        - not_pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, ...)"
-    - pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ENCRYPTION, ...)"
+        - not_pattern: "aws_cdk.aws_s3.Bucket(<ANY>, encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, <ANY>)"
+    - pattern: "aws_cdk.aws_s3.Bucket(<ANY>, encryption=aws_cdk.aws_s3.BucketEncryption.$ENCRYPTION, <ANY>)"
       conditions:
         - metavariable: $ENCRYPTION
           regex: ^(S3_MANAGED|UNENCRYPTED)$

--- a/checkov/cdk/checks/python/S3BucketKMSEncryption.yaml
+++ b/checkov/cdk/checks/python/S3BucketKMSEncryption.yaml
@@ -1,25 +1,18 @@
 metadata:
-  version: 0.1
+  version: 0.2
   id: CKV_AWS_145
   name: Ensure that S3 buckets are encrypted with KMS by default
   category: ENCRYPTION
+  approach: define failing
 scope:
   languages:
     - python
 definition:
   - or:
-      - and:
-          - cond_type: pattern
-            operator: equals
-            value: "aws_cdk.aws_s3.Bucket(...)"
-          - cond_type: pattern
-            operator: not_equals
-            value: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, ...)"
-      - and:
-          - cond_type: variable
-            variable: $ENCRYPTION
-            operator: regex_match
-            value: ^(S3_MANAGED|UNENCRYPTED)$
-          - cond_type: pattern
-            operator: equals
-            value: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ENCRYPTION, ...)"
+    - pattern: "aws_cdk.aws_s3.Bucket(...)"
+      conditions:
+        - not_pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ANY_VAR, ...)"
+    - pattern: "aws_cdk.aws_s3.Bucket(..., encryption=aws_cdk.aws_s3.BucketEncryption.$ENCRYPTION, ...)"
+      conditions:
+        - metavariable: $ENCRYPTION
+          regex: ^(S3_MANAGED|UNENCRYPTED)$

--- a/checkov/cdk/checks/python/S3BucketKMSEncryption.yaml
+++ b/checkov/cdk/checks/python/S3BucketKMSEncryption.yaml
@@ -7,6 +7,7 @@ metadata:
 scope:
   languages:
     - python
+#TODO: move to metavariable when nested metavariables is an option
 definition:
   - or:
     - pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"

--- a/checkov/cdk/checks/python/S3BucketLogging.yaml
+++ b/checkov/cdk/checks/python/S3BucketLogging.yaml
@@ -1,16 +1,13 @@
 metadata:
-  version: 0.1
+  version: 0.2
   id: CKV_AWS_18
   name: Ensure the S3 bucket has access logging enabled
   category: LOGGING
+  approach: define failing
 scope:
   languages:
     - python
 definition:
-  - and:
-      - cond_type: pattern
-        operator: equals
-        value: "aws_cdk.aws_s3.Bucket(...)"
-      - cond_type: pattern
-        operator: not_equals
-        value: "aws_cdk.aws_s3.Bucket(..., server_access_logs_bucket=$ANY_VAR, ...)"
+  pattern: "aws_cdk.aws_s3.Bucket(...)"
+  conditions:
+    - not_pattern: "aws_cdk.aws_s3.Bucket(..., server_access_logs_bucket=$ANY_VAR, ...)"

--- a/checkov/cdk/checks/python/S3BucketLogging.yaml
+++ b/checkov/cdk/checks/python/S3BucketLogging.yaml
@@ -8,6 +8,6 @@ scope:
   languages:
     - python
 definition:
-  pattern: "aws_cdk.aws_s3.Bucket(...)"
+  pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"
   conditions:
-    - not_pattern: "aws_cdk.aws_s3.Bucket(..., server_access_logs_bucket=$ANY_VAR, ...)"
+    - not_pattern: "aws_cdk.aws_s3.Bucket(<ANY>, server_access_logs_bucket=$ANY_VAR, <ANY>)"

--- a/checkov/cdk/checks/python/S3BucketPublicAccessBlock.yaml
+++ b/checkov/cdk/checks/python/S3BucketPublicAccessBlock.yaml
@@ -1,16 +1,13 @@
 metadata:
-  version: 0.1
+  version: 0.2
   id: CKV2_AWS_6
   name: Ensure that S3 bucket has a Public Access block
   category: NETWORKING
+  approach: define failing
 scope:
   languages:
     - python
 definition:
-  - and:
-      - cond_type: pattern
-        operator: equals
-        value: "aws_cdk.aws_s3.Bucket(...)"
-      - cond_type: pattern
-        operator: not_equals
-        value: "aws_cdk.aws_s3.Bucket(..., block_public_access=$ANY_VAR, ...)"
+  pattern: "aws_cdk.aws_s3.Bucket(...)"
+  conditions:
+    not_pattern: "aws_cdk.aws_s3.Bucket(..., block_public_access=$ANY_VAR, ...)"

--- a/checkov/cdk/checks/python/S3BucketPublicAccessBlock.yaml
+++ b/checkov/cdk/checks/python/S3BucketPublicAccessBlock.yaml
@@ -8,6 +8,6 @@ scope:
   languages:
     - python
 definition:
-  pattern: "aws_cdk.aws_s3.Bucket(...)"
+  pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"
   conditions:
-    not_pattern: "aws_cdk.aws_s3.Bucket(..., block_public_access=$ANY_VAR, ...)"
+    not_pattern: "aws_cdk.aws_s3.Bucket(<ANY>, block_public_access=$ANY_VAR, <ANY>)"

--- a/checkov/cdk/checks/python/S3BucketVersioning.yaml
+++ b/checkov/cdk/checks/python/S3BucketVersioning.yaml
@@ -8,6 +8,6 @@ scope:
   languages:
     - python
 definition:
-  pattern: "aws_cdk.aws_s3.Bucket(...)"
+  pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"
   conditions:
-    not_pattern: "aws_cdk.aws_s3.Bucket(..., versioned=True, ...)"
+    not_pattern: "aws_cdk.aws_s3.Bucket(<ANY>, versioned=True, <ANY>)"

--- a/checkov/cdk/checks/python/S3BucketVersioning.yaml
+++ b/checkov/cdk/checks/python/S3BucketVersioning.yaml
@@ -7,6 +7,7 @@ metadata:
 scope:
   languages:
     - python
+#TODO: Add metavariable when nested is an option
 definition:
   pattern: "aws_cdk.aws_s3.Bucket(<ANY>)"
   conditions:

--- a/checkov/cdk/checks/python/S3BucketVersioning.yaml
+++ b/checkov/cdk/checks/python/S3BucketVersioning.yaml
@@ -1,16 +1,13 @@
 metadata:
-  version: 0.1
+  version: 0.2
   id: CKV_AWS_21
   name: Ensure all data stored in the S3 bucket have versioning enabled
   category: BACKUP_AND_RECOVERY
+  approach: define failing
 scope:
   languages:
     - python
 definition:
-  - and:
-      - cond_type: pattern
-        operator: equals
-        value: "aws_cdk.aws_s3.Bucket(...)"
-      - cond_type: pattern
-        operator: not_equals
-        value: "aws_cdk.aws_s3.Bucket(..., versioned=True, ...)"
+  pattern: "aws_cdk.aws_s3.Bucket(...)"
+  conditions:
+    not_pattern: "aws_cdk.aws_s3.Bucket(..., versioned=True, ...)"


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Convert Python CDK policies to V0.2 syntax