### PR TITLE
platform(general): require a repo ID when using API key

### DIFF
--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -328,7 +328,7 @@ class ExtArgumentParser(configargparse.ArgumentParser):
         )
         self.add(
             "--repo-id",
-            help="Identity string of the repository, with form <repo_owner>/<repo_name>",
+            help="Identity string of the repository, with form <repo_owner>/<repo_name>. Required when using the platform integration.",
         )
         self.add(
             "-b",

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -328,7 +328,7 @@ class ExtArgumentParser(configargparse.ArgumentParser):
         )
         self.add(
             "--repo-id",
-            help="Identity string of the repository, with form <repo_owner>/<repo_name>. Required when using the platform integration.",
+            help="Identity string of the repository, with form <repo_owner>/<repo_name>. Required when using the platform integration (API key).",
         )
         self.add(
             "-b",

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -199,6 +199,9 @@ class Checkov:
         if self.config.use_enforcement_rules and not self.config.bc_api_key:
             self.parser.error('Must specify an API key with --use-enforcement-rules')
 
+        if self.config.bc_api_key and not self.config.repo_id:
+            self.parser.error('--repo-id is required when using a platform API key')
+
         if self.config.policy_metadata_filter and not (self.config.bc_api_key and self.config.prisma_api_url):
             logger.warning(
                 '--policy-metadata-filter flag was used without a Prisma Cloud API key. Policy filtering will be skipped.'


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Fails argument parsing if API key is used but repo-id is not provided.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
