### PR TITLE
feat(general): Normalize framework flags

### DIFF
--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -20,6 +20,7 @@ def flatten_csv(l: List[List[str]]) -> List[str]:
     Flattens a list of list of strings into a list of strings, while also splitting out comma-separated values
     Duplicates will be removed.
     [['terraform', 'arm'], ['bicep,cloudformation,arm']] -> ['terraform', 'arm', 'bicep', 'cloudformation']
+    (Order is not guaranteed)
     """
     if not l:
         return []

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -223,7 +223,7 @@ class ExtArgumentParser(configargparse.ArgumentParser):
         )
         self.add(
             "--framework",
-            help="Filter scan to run only on specific infrastructure code frameworks. Defaults to all frameworks. If you "
+            help="Filter scan to run only on specific infrastructure as code frameworks. Defaults to all frameworks. If you "
                  "explicitly include 'all' as a value, then all other values are ignored. Enter as a "
                  "comma-separated list or repeat the flag multiple times. For example, --framework terraform,sca_package "
                  f"or --framework terraform --framework sca_package. Possible values: {', '.join(['all'] + checkov_runners)}",

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -24,7 +24,7 @@ def flatten_csv(list_to_flatten: List[List[str]]) -> List[str]:
     """
     if not list_to_flatten:
         return []
-    return list(set([s for sublist in list_to_flatten for val in sublist for s in val.split(',')]))
+    return list({s for sublist in list_to_flatten for val in sublist for s in val.split(',')})
 
 
 class ExtArgumentParser(configargparse.ArgumentParser):

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -211,18 +211,20 @@ class ExtArgumentParser(configargparse.ArgumentParser):
         )
         self.add(
             "--framework",
-            help="Filter scan to run only on specific infrastructure code frameworks",
-            choices=checkov_runners + sast_types + ["all"],
+            help="Filter scan to run only on specific infrastructure code frameworks. Enter as a comma-separated list or "
+                 "repeat the flag multiple times. For example, --framework terraform,sca_package or --framework terraform "
+                 f"--framework sca_package. Possible values: {', '.join(['all'] + checkov_runners)}",
             default=["all"],
             env_var="CKV_FRAMEWORK",
-            nargs="+",
+            action='append'
         )
         self.add(
             "--skip-framework",
-            help="Filter scan to skip specific infrastructure as code frameworks."
+            help="Filter scan to skip specific infrastructure as code frameworks. "
                  "This will be included automatically for some frameworks if system dependencies "
-                 "are missing. Add multiple frameworks using spaces. For example, "
-                 "--skip-framework terraform sca_package.",
+                 "are missing. Enter as a comma-separated list or repeat the flag multiple times. For example, "
+                 "--skip-framework terraform,sca_package or --skip-framework terraform --skip-framework sca_package."
+                 f"Possible values: {', '.join(checkov_runners)}",
             choices=checkov_runners,
             default=None,
             nargs="+",

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -222,7 +222,8 @@ class ExtArgumentParser(configargparse.ArgumentParser):
         )
         self.add(
             "--framework",
-            help="Filter scan to run only on specific infrastructure code frameworks. Defaults to all frameworks. Enter as a "
+            help="Filter scan to run only on specific infrastructure code frameworks. Defaults to all frameworks. If you "
+                 "explicitly include 'all' as a value, then all other values are ignored. Enter as a "
                  "comma-separated list or repeat the flag multiple times. For example, --framework terraform,sca_package "
                  f"or --framework terraform --framework sca_package. Possible values: {', '.join(['all'] + checkov_runners)}",
             env_var="CKV_FRAMEWORK",
@@ -235,7 +236,8 @@ class ExtArgumentParser(configargparse.ArgumentParser):
             help="Filter scan to skip specific infrastructure as code frameworks. "
                  "This will be included automatically for some frameworks if system dependencies "
                  "are missing. Enter as a comma-separated list or repeat the flag multiple times. For example, "
-                 "--skip-framework terraform,sca_package or --skip-framework terraform --skip-framework sca_package."
+                 "--skip-framework terraform,sca_package or --skip-framework terraform --skip-framework sca_package. "
+                 "Cannot include values that are also included in --framework. "
                  f"Possible values: {', '.join(checkov_runners)}",
             default=None,
             action='append',

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -5,7 +5,7 @@ from typing import Any, TYPE_CHECKING, cast, List
 
 import configargparse
 
-from checkov.common.bridgecrew.check_type import checkov_runners, sast_types
+from checkov.common.bridgecrew.check_type import checkov_runners
 from checkov.common.runners.runner_registry import OUTPUT_CHOICES, SUMMARY_POSITIONS
 from checkov.common.util.consts import DEFAULT_EXTERNAL_MODULES_DIR
 from checkov.common.util.type_forcers import convert_str_to_bool
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     import argparse
 
 
-def flatten_csv(l: List[List[str]]) -> List[str]:
+def flatten_csv(list_to_flatten: List[List[str]]) -> List[str]:
     """
     Flattens a list of list of strings into a list of strings, while also splitting out comma-separated values
     Duplicates will be removed.
@@ -24,7 +24,7 @@ def flatten_csv(l: List[List[str]]) -> List[str]:
     """
     if not l:
         return []
-    return list(set([s for sublist in l for val in sublist for s in val.split(',')]))
+    return list(set([s for sublist in list_to_flatten for val in sublist for s in val.split(',')]))
 
 
 class ExtArgumentParser(configargparse.ArgumentParser):

--- a/checkov/common/util/ext_argument_parser.py
+++ b/checkov/common/util/ext_argument_parser.py
@@ -22,7 +22,7 @@ def flatten_csv(list_to_flatten: List[List[str]]) -> List[str]:
     [['terraform', 'arm'], ['bicep,cloudformation,arm']] -> ['terraform', 'arm', 'bicep', 'cloudformation']
     (Order is not guaranteed)
     """
-    if not l:
+    if not list_to_flatten:
         return []
     return list(set([s for sublist in list_to_flatten for val in sublist for s in val.split(',')]))
 

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -225,7 +225,7 @@ class Checkov:
             # it is passed as a list of lists
             self.config.file = list(itertools.chain.from_iterable(self.config.file))
 
-    def normalize_framework_arg(self, raw_framework_arg, handle_all=False):
+    def normalize_framework_arg(self, raw_framework_arg: List[List[str]], handle_all=False) -> List[str]:
         # frameworks come as arrays of arrays, e.g. --framework terraform arm --framework bicep,cloudformation
         # becomes: [['terraform', 'arm'], ['bicep,cloudformation']]
         # we'll collapse it into a single array (which is how it was before checkov3)

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -214,7 +214,7 @@ class Checkov:
         self.config.skip_framework = self.normalize_framework_arg(self.config.skip_framework)
         logging.debug(f'Normalized --skip-framework value: {self.config.skip_framework}')
 
-        duplicate_frameworks = list(filter(lambda f: f in self.config.framework, self.config.skip_framework))
+        duplicate_frameworks = set(self.config.skip_framework).intersection(self.config.framework)
         if duplicate_frameworks:
             self.parser.error(f'Frameworks listed for both --framework and --skip-framework: {", ".join(duplicate_frameworks)}')
 

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -12,7 +12,7 @@ import signal
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, List
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, List, cast
 
 import argcomplete
 import configargparse
@@ -53,7 +53,7 @@ from checkov.common.util import prompt
 from checkov.common.util.banner import banner as checkov_banner, tool as checkov_tool
 from checkov.common.util.config_utils import get_default_config_paths
 from checkov.common.util.consts import CHECKOV_RUN_SCA_PACKAGE_SCAN_V2
-from checkov.common.util.ext_argument_parser import ExtArgumentParser
+from checkov.common.util.ext_argument_parser import ExtArgumentParser, flatten_csv
 from checkov.common.util.runner_dependency_handler import RunnerDependencyHandler
 from checkov.common.util.type_forcers import convert_str_to_bool
 from checkov.contributor_metrics import report_contributor_metrics
@@ -175,14 +175,8 @@ class Checkov:
 
         self.config = self.parser.parse_args(argv)
         self.normalize_config()
-        logging.error('Exiting')
-        sys.exit(0)
 
     def normalize_config(self) -> None:
-
-        logging.error('Config:')
-        logging.error(self.config)
-
         if self.config.no_guide:
             logger.warning(
                 '--no-guide is deprecated and will be removed in a future release. Use --skip-download instead'
@@ -212,12 +206,56 @@ class Checkov:
                 '--policy-metadata-filter flag was used without a Prisma Cloud API key. Policy filtering will be skipped.'
             )
 
+        self.normalize_frameworks()
+
         # Parse mask into json with default dict. If self.config.mask is empty list, default dict will be assigned
         self._parse_mask_to_resource_attributes_to_omit()
 
         if self.config.file:
             # it is passed as a list of lists
             self.config.file = list(itertools.chain.from_iterable(self.config.file))
+
+    def normalize_frameworks(self):
+        # frameworks come as arrays of arrays, e.g. --framework terraform arm --framework bicep,cloudformation
+        # becomes: [['terraform', 'arm'], ['bicep,cloudformation']]
+        # we'll collapse it into a single array (which is how it was before checkov3)
+
+        if self.config.framework:
+            logging.debug(f'Raw framework value: {self.config.framework}')
+            frameworks = flatten_csv(cast(List[List[str]], self.config.framework))
+            logging.debug(f'Flattened frameworks: {frameworks}')
+            if 'all' in frameworks:
+                self.config.framework = ['all']
+            else:
+                invalid = list(filter(lambda f: f not in checkov_runners, frameworks))
+                if invalid:
+                    self.parser.error(f'Invalid frameworks specified: {", ".join(invalid)}.{os.linesep}'
+                                      f'Valid values are: {", ".join(["all"] + checkov_runners)}')
+                self.config.framework = frameworks
+        else:
+            logging.debug('No framework specified; setting to `all`')
+            self.config.framework = ['all']
+
+        logging.debug(f'Normalized --framework value: {self.config.framework}')
+
+        if self.config.skip_framework:
+            logging.debug(f'Raw skip framework value: {self.config.skip_framework}')
+            frameworks = flatten_csv(cast(List[List[str]], self.config.skip_framework))
+            logging.debug(f'Flattened skip frameworks: {frameworks}')
+
+            invalid = list(filter(lambda f: f not in checkov_runners, frameworks))
+            if invalid:
+                self.parser.error(f'Invalid skip frameworks specified: {", ".join(invalid)}.{os.linesep}'
+                                  f'Valid values are: {", ".join(checkov_runners)}')
+            self.config.skip_framework = frameworks
+        else:
+            self.config.skip_framework = []
+
+        logging.debug(f'Normalized --skip-framework value: {self.config.skip_framework}')
+
+        duplicate = list(filter(lambda f: f in self.config.framework, self.config.skip_framework))
+        if duplicate:
+            self.parser.error(f'Frameworks listed for both --framework and --skip-framework: {", ".join(duplicate)}')
 
     def run(self, banner: str = checkov_banner, tool: str = checkov_tool, source_type: SourceType | None = None) -> int | None:
         self.run_metadata = {

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -175,6 +175,8 @@ class Checkov:
 
         self.config = self.parser.parse_args(argv)
         self.normalize_config()
+        logging.error('Exiting')
+        sys.exit(0)
 
     def normalize_config(self) -> None:
         if self.config.no_guide:

--- a/checkov/main.py
+++ b/checkov/main.py
@@ -179,6 +179,10 @@ class Checkov:
         sys.exit(0)
 
     def normalize_config(self) -> None:
+
+        logging.error('Config:')
+        logging.error(self.config)
+
         if self.config.no_guide:
             logger.warning(
                 '--no-guide is deprecated and will be removed in a future release. Use --skip-download instead'

--- a/tests/config/TestCLIArgs.py
+++ b/tests/config/TestCLIArgs.py
@@ -1,0 +1,117 @@
+import unittest
+
+from checkov.main import Checkov
+
+
+class ConfigException(Exception):
+    pass
+
+
+# override parser.error, which prints the error and exits
+def parser_error(message: str):
+    raise ConfigException(message)
+
+
+class TestCLIArgs(unittest.TestCase):
+    def test_normalize_frameworks(self):
+        argv = []
+        ckv = Checkov(argv=argv)
+        self.assertEqual(ckv.config.framework, ['all'])
+        self.assertEqual(ckv.config.skip_framework, [])
+
+        argv = ['--framework', 'terraform']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(ckv.config.framework, ['terraform'])
+
+        argv = ['--framework', 'terraform,arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.framework), {'terraform', 'arm'})
+
+        argv = ['--framework', 'terraform', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.framework), {'terraform', 'arm'})
+
+        argv = ['--framework', 'terraform', '--framework', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.framework), {'terraform', 'arm'})
+
+        argv = ['--framework', 'terraform,bicep', '--framework', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.framework), {'terraform', 'arm', 'bicep'})
+
+        argv = ['--framework', 'terraform,bicep', '--framework', 'arm,all']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(ckv.config.framework, ['all'])
+
+        argv = ['--framework', 'terraform,bicep', '--framework', 'arm,invalid']
+        ckv = Checkov(argv=[])  # first instantiate a valid one
+        # now repeat some of the logic of the constructor, overriding values
+        ckv.config = ckv.parser.parse_args(argv)
+        ckv.parser.error = parser_error
+        with self.assertRaises(ConfigException):
+            ckv.normalize_config()
+
+        # all is specified, so we do not expect an exception
+        argv = ['--framework', 'terraform,bicep', '--framework', 'arm,invalid,all']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(ckv.config.framework, ['all'])
+
+    def test_normalize_skip_frameworks(self):
+        argv = ['--skip-framework', 'terraform']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(ckv.config.skip_framework, ['terraform'])
+
+        argv = ['--skip-framework', 'terraform,arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.skip_framework), {'terraform', 'arm'})
+
+        argv = ['--skip-framework', 'terraform', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.skip_framework), {'terraform', 'arm'})
+
+        argv = ['--skip-framework', 'terraform', '--skip-framework', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.skip_framework), {'terraform', 'arm'})
+
+        argv = ['--skip-framework', 'terraform,bicep', '--skip-framework', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(set(ckv.config.skip_framework), {'terraform', 'arm', 'bicep'})
+
+        # all is not allowed
+        argv = ['--skip-framework', 'terraform,bicep', '--skip-framework', 'arm,all']
+        ckv = Checkov(argv=[])
+        ckv.config = ckv.parser.parse_args(argv)
+        ckv.parser.error = parser_error
+        with self.assertRaises(ConfigException):
+            ckv.normalize_config()
+
+        argv = ['--skip-framework', 'terraform,bicep', '--skip-framework', 'arm,invalid']
+        ckv = Checkov(argv=[])
+        ckv.config = ckv.parser.parse_args(argv)
+        ckv.parser.error = parser_error
+        with self.assertRaises(ConfigException):
+            ckv.normalize_config()
+
+    def test_combine_framework_and_skip(self):
+        argv = ['--framework', 'terraform', '--skip-framework', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(ckv.config.framework, ['terraform'])
+        self.assertEqual(ckv.config.skip_framework, ['arm'])
+
+        # duplicate values not allowed
+        argv = ['--framework', 'arm', '--skip-framework', 'arm']
+        ckv = Checkov(argv=[])
+        ckv.config = ckv.parser.parse_args(argv)
+        ckv.parser.error = parser_error
+        with self.assertRaises(ConfigException):
+            ckv.normalize_config()
+
+        # but it works with all
+        argv = ['--framework', 'arm,all', '--skip-framework', 'arm']
+        ckv = Checkov(argv=argv)
+        self.assertEqual(ckv.config.framework, ['all'])
+        self.assertEqual(ckv.config.skip_framework, ['arm'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sast|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

Adds the ability to specify `--framework` and `--skip-framework` using CSV values and by repeating the flag, to align with `--check`. The following are all valid and equivalent:

- `--framework terraform arm` (old way)
- `--framework terraform --framework arm`
- `--framework terraform,arm`

Same applies to `--skip-framework`.

Because we are no longer relying on argparse `choices` to do validation, also adds validation and normalization to create a flat list of arrays so that downstream logic does not notice any differences.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
